### PR TITLE
Refactor Dockerfile for better caching + COPY instead of ADD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,3 @@ COPY bin bin
 COPY routes routes
 COPY public public
 COPY views views
-
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,12 @@ FROM registry.cto.ai/official_images/node:2-12.13.1-stretch-slim
 WORKDIR /ops
 
 ADD package.json .
+RUN npm install --production
+
 ADD app.js .
 ADD bin bin
 ADD routes routes
 ADD public public
 ADD views views
 
-RUN npm install --production
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,13 @@ FROM registry.cto.ai/official_images/node:2-12.13.1-stretch-slim
 
 WORKDIR /ops
 
-ADD package.json .
+COPY package.json .
 RUN npm install --production
 
-ADD app.js .
-ADD bin bin
-ADD routes routes
-ADD public public
-ADD views views
+COPY app.js .
+COPY bin bin
+COPY routes routes
+COPY public public
+COPY views views
 
 


### PR DESCRIPTION
To avoid needing to install dependencies after every code modification, we can move the install step between copying the `package.json` and the rest of the source code.

Also, replaces `ADD` with `COPY` based on the [Dockerfile best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy) (since none of the tar extraction / URL magic of `ADD` is needed here) 